### PR TITLE
check_gcc_output: avoid matching dependency generation commands using -MM

### DIFF
--- a/checks-data/check_gcc_output
+++ b/checks-data/check_gcc_output
@@ -219,7 +219,7 @@ while (<>) {
     my $iscompilerline = 0;
     if (/^(|.*[\s;\/]+)(gcc|cc|g\+\+) .*/i) {
         # avoid make dep lines...
-        $iscompilerline = 1 if (! /(-E|-MD|-shared|gccmakedep)/);
+        $iscompilerline = 1 if (! /(-E|-MD|-MM|-shared|gccmakedep)/);
         $iscompilerline = 1 if (/-MD/ && /\.o /); # -MD and object output
     }
     # libtool needs some special love.


### PR DESCRIPTION
...M
