### PR TITLE
an empty main() is now allowed in C, use a different function

### DIFF
--- a/tests/xx7.c
+++ b/tests/xx7.c
@@ -1,2 +1,2 @@
-int main(int argc, char **argv) {
+int f() {
 }


### PR DESCRIPTION
this fixes testcase 7 for gcc 5.0 usage