### PR TITLE
Do not remove packages that had a corresponding -mini installed

### DIFF
--- a/checks/99-check-remove-rpms
+++ b/checks/99-check-remove-rpms
@@ -52,6 +52,8 @@ for RPM in `reorder "${RPM_FILE_LIST[@]}"`; do
     PKG=${PKG%.rpm}
     # Do not remove installed packages
     test -e "$BUILD_ROOT/installed-pkg/$PKG" && continue
+    # Do not remove packages that have a corresponding -mini installed (used to avoid cycles)
+    test -e "$BUILD_ROOT/installed-pkg/$PKG-mini" && continue
     # Nor packages differing in the shlib version like libreadline5 vs.
     # libreadline6
     PKG1=${PKG%[0-9]}[0-9]


### PR DESCRIPTION
This helps in cases like current Staging:B, where

* pam is newly linked against krb5 (due to the move from sun rpc over to tirpc)
* while building krb5, krb5-mini is installed into the buildroot (incl. the libraries)
* krb5 is being built, installed, removed
* for the brp checks, su is being used, but fails as pam_unix is linked to libkrb5, which has 'just been removed' again (the file was also part of krb5-mini)

Hence, avoiding that a pkg is removed if its corresponding -mini was present helps avoid this problem.

Solves the error currently seen in:
https://build.opensuse.org/package/live_build_log/openSUSE:Factory:Staging:B/krb5/standard/x86_64