### PR TITLE
use fixed hash seed values for perl+python

### DIFF
--- a/suse-buildsystem.sh
+++ b/suse-buildsystem.sh
@@ -1,3 +1,5 @@
 export SUSE_IGNORED_RPATHS=/etc/suse-ignored-rpaths.conf
 export SUSE_ASNEEDED=1
+export PERL_HASH_SEED=42
+export PYTHONHASHSEED=42
 


### PR DESCRIPTION
to allow packages like
perl-Apache-SessionX and python3-jupyter_nbconvert-doc
that output unordered hash values into the rpm
to have reproducible results (to make build-compare happy)
without finding and patching each such package individually

This change worked fine in my tests.