### PR TITLE
export QT_HASH_SEED

### DIFF
--- a/suse-buildsystem.sh
+++ b/suse-buildsystem.sh
@@ -1,5 +1,6 @@
 export SUSE_IGNORED_RPATHS=/etc/suse-ignored-rpaths.conf
 export SUSE_ASNEEDED=1
+export QT_HASH_SEED=42
 export PERL_HASH_SEED=42
 export PYTHONHASHSEED=0
 


### PR DESCRIPTION
This is required to make packages
pimcommon kpimtextedit akonadi-server kdelibs4support kdesignerplugin
build reproducibly, because qt5's moc tool uses a [QHash](http://doc.qt.io/qt-5/qhash.html#qSetGlobalQHashSeed)
to produce .cpp files that get linked into
/usr/lib64/qt5/plugins/designer/FOO.so files