### PR TITLE
Add suse-ignored-rpaths.conf

### DIFF
--- a/suse-ignored-rpaths.conf
+++ b/suse-ignored-rpaths.conf
@@ -1,0 +1,11 @@
+/usr/lib
+/usr/lib64
+/usr/local/lib
+/usr/local/lib64
+/lib
+/lib64
+/usr/lib/Xaw3d
+/usr/lib64/Xaw3d
+/usr/x86_64-suse-linux/lib
+/opt/kde3/lib
+/opt/kde3/lib64


### PR DESCRIPTION
To solve https://bugzilla.opensuse.org/show_bug.cgi?id=1109470
it is nicer to track this file in git
instead of the .spec file

content is the previous content with `%_lib` expanded to both `lib` and `lib64`