### PR TITLE
Ignore ghosts

### DIFF
--- a/checks-data/findfileconflicts
+++ b/checks-data/findfileconflicts
@@ -217,13 +217,13 @@ if ($manifest) {
 	  $modes_ghost[$m] = $ff & 0100;
 	}
 	my $f = "$n/$bn";
-	if (exists $files{$f}) {
-	  if (($ff & 0100) != 0) {
+	if (($ff & 0100) != 0) {
+	  if (exists $files{$f}) {
 	    $filesc{$f} ||= [ $files{$f} ];
 	    push @{$filesc{$f}}, "$pkg/$m";
+	  } else {
+	    $files{$f} = "$pkg/$m";
 	  }
-	} else {
-	  $files{$f} = "$pkg/$m";
 	}
       }
     }

--- a/checks-data/findfileconflicts
+++ b/checks-data/findfileconflicts
@@ -218,8 +218,10 @@ if ($manifest) {
 	}
 	my $f = "$n/$bn";
 	if (exists $files{$f}) {
-	  $filesc{$f} ||= [ $files{$f} ];
-	  push @{$filesc{$f}}, "$pkg/$m";
+	  if (($ff & 0100) != 0) {
+	    $filesc{$f} ||= [ $files{$f} ];
+	    push @{$filesc{$f}}, "$pkg/$m";
+	  }
 	} else {
 	  $files{$f} = "$pkg/$m";
 	}


### PR DESCRIPTION
Fixing #24 (https://github.com/openSUSE/post-build-checks/issues/24). Ghosts are not really files and don't take part in conflicts so there is no need to push them to check.