### PR TITLE
Tweaks to make rpm-ndb build

### DIFF
--- a/checks/00-check-install-rpms
+++ b/checks/00-check-install-rpms
@@ -5,6 +5,15 @@ TOPDIR=/usr/src/packages
 test -d $BUILD_ROOT/.build.packages && TOPDIR=/.build.packages
 export YAST_IS_RUNNING="instsys"
 RPM_FILE_LIST=(`find $BUILD_ROOT$TOPDIR/RPMS -type f -name "*.rpm"`)
+for rpm in $RPM_FILE_LIST ; do
+  case ${rpm##*/} in
+    rpm-ndb-*) 
+      echo "converting rpm database to ndb"
+      chroot $BUILD_ROOT rpmdb --define '_db_backend ndb' --rebuilddb
+      ;;
+  esac
+done
+
 ADDITIONAL_PARAMS=
 test "$ABUILD_INIT_WITH_IGNORE_ARCH" = true && ADDITIONAL_PARAMS="$ADDITIONAL_PARAMS --ignorearch"
 chroot $BUILD_ROOT rpm $ADDITIONAL_PARAMS --force --nodeps -Uv ${RPM_FILE_LIST[*]#$BUILD_ROOT} || {

--- a/checks/99-check-remove-rpms
+++ b/checks/99-check-remove-rpms
@@ -65,9 +65,11 @@ for RPM in `reorder "${RPM_FILE_LIST[@]}"`; do
 	echo "(keeping $PKG because of $N)"
 	continue
     fi
-    # Do not remove libgcc or libstdc++ variants
+    # Do not remove libgcc/libstdc++ variants or rpm/rpm-build/rpm-ndb
     case ${PKG} in
     libgcc*|libstdc++*)
+	;;
+    rpm|rpm-build|rpm-ndb)
 	;;
     *)
 	RPM_ERASE_LIST="$RPM_ERASE_LIST $PKG"


### PR DESCRIPTION
- we need to convert the rpm database from bdb to ndb before
  rpm-ndb is installed because rpm-ndb cannot read a berkeley db
  database
- we must not deinstall rpm-ndb because it is needed for baselibs
  generation