### PR TITLE
99-check-remove-rpms: preserve libgomp variants

### DIFF
--- a/checks/99-check-remove-rpms
+++ b/checks/99-check-remove-rpms
@@ -65,9 +65,9 @@ for RPM in `reorder "${RPM_FILE_LIST[@]}"`; do
 	echo "(keeping $PKG because of $N)"
 	continue
     fi
-    # Do not remove libgcc or libstdc++ variants
+    # Do not remove libgcc, libstdc++ and libgomp variants
     case ${PKG} in
-    libgcc*|libstdc++*)
+    libgcc*|libgomp*|libstdc++*)
 	;;
     *)
 	RPM_ERASE_LIST="$RPM_ERASE_LIST $PKG"


### PR DESCRIPTION
The package libgomp1 is being pulled in by RPM (since 4.15, for parallel processing).
While building alternative versions of gcc, the post-build-checks install (forcibly)
libgomp1-gccX, overwriting /usr/lib64/libgomp.so.1. Later on, the RPMs are being uninstalled again,
resulting in libgomp.so.1 being deleted (libgomp1 being broken)

Any future call to RPM will fail, as depending libraries are now missing. Since this is the same
special case as with libgcc and libstdc++, we handle libgomp the same way by keeping the freshly
built RPM installed