### PR TITLE
Fix ghost logic

### DIFF
--- a/checks-data/findfileconflicts
+++ b/checks-data/findfileconflicts
@@ -217,7 +217,7 @@ if ($manifest) {
 	  $modes_ghost[$m] = $ff & 0100;
 	}
 	my $f = "$n/$bn";
-	if (($ff & 0100) != 0) {
+	if (($ff & 0100) == 0) {
 	  if (exists $files{$f}) {
 	    $filesc{$f} ||= [ $files{$f} ];
 	    push @{$filesc{$f}}, "$pkg/$m";


### PR DESCRIPTION
Ghost files are flagged with a bit. So we need to check for absence
of the bit if we want to put non-ghost files into the hash. The
previous logic would only put ghost files into the hash.