### PR TITLE
Add 51-rpmlint.

### DIFF
--- a/checks/51-rpmlint
+++ b/checks/51-rpmlint
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+TOPDIR=/usr/src/packages
+test -d $BUILD_ROOT/.build.packages && TOPDIR=/.build.packages
+
+RPMLINT_CHROOT="$BUILD_ROOT/usr/lib/rpmlint-image"
+WORKDIR=$RPMLINT_CHROOT/RPM
+
+mount --bind $BUILD_ROOT$TOPDIR $WORKDIR
+
+RPMLINTRC_OPTION=$(ls $WORKDIR/SOURCES | grep rpmlintrc | sed "s,$WORKDIR,,")
+if ! [ -z "$RPMLINTRC_OPTION" ] ; then
+  RPMLINTRC_OPTION="-r /RPM/SOURCES/$RPMLINTRC_OPTION"
+fi
+RPM_FILES=$(find $RPMLINT_CHROOT -type f -name '*.rpm' | sed "s,$RPMLINT_CHROOT,,")
+
+set -o pipefail
+chroot $RPMLINT_CHROOT /usr/bin/rpmlint --info --permissive $RPMLINTRC_OPTION $RPM_FILES > >(tee $BUILD_ROOT$TOPDIR/OTHER/rpmlint.log) 2>&1
+
+umount $RPMLINT_CHROOT/RPM


### PR DESCRIPTION
For rpmlint 2.0 we will need chroot execution uses rpmlint-image package.

I've tested that locally with `-x rpmlint-image`:

```
[   15s] ... testing for modified permissions
[   16s] ... running 51-rpmlint
[   17s] ============================ rpmlint session starts ============================
[   17s] rpmlint: 2.0.0
[   17s] configuration:
[   17s]     /usr/lib/python3.8/site-packages/rpmlint/configdefaults.toml
[   17s]     /etc/xdg/rpmlint/dbus-services.toml
[   17s]     /etc/xdg/rpmlint/licenses.toml
[   17s]     /etc/xdg/rpmlint/opensuse.toml
[   17s]     /etc/xdg/rpmlint/pam-modules.toml
[   17s]     /etc/xdg/rpmlint/pie-executables.toml
[   17s]     /etc/xdg/rpmlint/scoring.toml
[   17s]     /etc/xdg/rpmlint/security.toml
[   17s]     /etc/xdg/rpmlint/users-groups.toml
[   17s] rpmlintrc: RPM/bzip2-rpmlintrc
[   17s] checks: 36, packages: 5
[   17s] 
[   17s] bzip2.x86_64: W: unstripped-binary-or-object /usr/bin/bzip2
[   17s] bzip2.x86_64: W: unstripped-binary-or-object /usr/bin/bzip2recover
[   17s] libbz2-1.x86_64: W: unstripped-binary-or-object /usr/lib64/libbz2.so.1.0.6
[   17s] This executable should be stripped from debugging symbols, in order to take
[   17s] less space and be loaded faster. This is usually done automatically at
[   17s] buildtime by rpm.
[   17s] 
[   17s] libbz2-devel.x86_64: W: missing-dependency-on libbz2*/libbz2-libs/liblibbz2* = 1.0.8
[   17s] bzip2.x86_64: W: files-duplicate /usr/share/man/man1/bzcat.1.gz /usr/share/man/man1/bunzip2.1.gz
[   17s] bzip2.x86_64: W: files-duplicate /usr/share/man/man1/bzfgrep.1.gz /usr/share/man/man1/bzegrep.1.gz
[   17s] bzip2.x86_64: E: explicit-lib-dependency libbz2-1
[   17s] You must let rpm find the library dependencies by itself. Do not put unneeded
[   17s] explicit Requires: tags.
[   17s] 
[   17s]  5 packages and 0 specfiles checked; 1 errors, 6 warnings, 1 badness; has taken 0.8 s 
[   17s] ... running 98-revert-uname-hack
[   17s] ... running 99-check-remove-rpms
[   17s] ... removing all built rpms
```

Can you please @lnussel and @Vogtinator take a look?