### PR TITLE
Don't deinstall any pam_unix variant

### DIFF
--- a/checks/99-check-remove-rpms
+++ b/checks/99-check-remove-rpms
@@ -80,6 +80,8 @@ for RPM in `reorder "${RPM_FILE_LIST[@]}"`; do
 	;;
     bash-legacybin*|glibc-legacylib*)
 	;;
+    pam_unix*)
+	;;
     rpm|rpm-build|rpm-ndb)
 	;;
     *)


### PR DESCRIPTION
That's needed to have two pam_unix variants: one with and one without NIS support. If any of the pam_unix variants get removed, the build system will break.