### PR TITLE
support cross builds

### DIFF
--- a/checks/00-check-install-rpms
+++ b/checks/00-check-install-rpms
@@ -19,7 +19,23 @@ for rpm in `find $BUILD_ROOT$TOPDIR/RPMS -type f -name "*.rpm"`; do
 done
 
 ADDITIONAL_PARAMS=
+SKIP_INSTALL=
 test "$ABUILD_INIT_WITH_IGNORE_ARCH" = true && ADDITIONAL_PARAMS="$ADDITIONAL_PARAMS --ignorearch"
+
+SARCH=$(rpm -q --qf "%{ARCH}\n" aaa_base)
+for pack in $RPM_FILE_LIST ; do
+  TARCH=$(rpm -qp --qf "%{ARCH}" $pack)
+  test "$SARCH" != "$TARCH" && test "$TARCH" != "noarch" && {
+    SKIP_INSTALL=$TARCH
+  }
+done
+
+test -n "$SKIP_INSTALL" && {
+  echo "skipping installation of $SKIP_INSTALL rpms on $SARCH"
+  touch $BUILD_ROOT/skipped-install-cross
+  exit 0
+}
+
 chroot $BUILD_ROOT rpm $ADDITIONAL_PARAMS --force --nodeps -Uv ${RPM_FILE_LIST[*]#$BUILD_ROOT} || {
     echo 'failed to install rpms, aborting build'
     test -n "$BUILD_ROOT" && touch $BUILD_ROOT/not-ready

--- a/checks/50-check-installtest
+++ b/checks/50-check-installtest
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+test -e $BUILD_ROOT/skipped-install-cross && {
+    echo 'skipping pre/post install checks, install was skipped'
+    exit 0
+}
+
 echo "... testing for pre/postinstall scripts that are not idempotent"
 TOPDIR=/usr/src/packages
 test -d $BUILD_ROOT/.build.packages && TOPDIR=/.build.packages

--- a/checks/99-check-remove-rpms
+++ b/checks/99-check-remove-rpms
@@ -40,6 +40,12 @@ function reorder {
 #make sure it is mounted
 test -d $BUILD_ROOT/proc/sys || { echo "proc is not mounted"; exit 1; }
 
+test -e $BUILD_ROOT/skipped-install-cross && {
+    echo 'skipping removal of rpms, install was skipped'
+    rm -f $BUILD_ROOT/skipped-install-cross
+    exit 0
+}
+
 # test package removal
 echo "... removing all built rpms"
 export YAST_IS_RUNNING="instsys"


### PR DESCRIPTION
skip installing the built rpms if the architecture is neither
the target arch nor noarch and also subsequently skip the
pre/post install checks and the removal of the installed rpms