### PR TITLE
keep package that provides /usr/bin/sh

### DIFF
--- a/checks/99-check-remove-rpms
+++ b/checks/99-check-remove-rpms
@@ -52,12 +52,8 @@ export YAST_IS_RUNNING="instsys"
 RPM_ERASE_LIST=
 RPM_FILE_LIST=(`find $BUILD_ROOT$TOPDIR/RPMS -type f -name "*.rpm"`)
 
-coreutils=`chroot $BUILD_ROOT rpm --qf '%{NAME}\n' -qf /usr/bin/{date,cat,rm,chown}|sort -u`
-utillinux=`chroot $BUILD_ROOT rpm --qf '%{NAME}\n' -qf /usr/bin/su|sort -u`
-findutils=`chroot $BUILD_ROOT rpm --qf '%{NAME}\n' -qf /usr/bin/find|sort -u`
-gzip=`chroot $BUILD_ROOT rpm --qf '%{NAME}\n' -qf /usr/bin/gzip|sort -u`
-cpio=`chroot $BUILD_ROOT rpm --qf '%{NAME}\n' -qf /usr/bin/cpio|sort -u`
-shell=`chroot $BUILD_ROOT rpm --qf '%{NAME}\n' -qf /usr/bin/sh|sort -u`
+# essential deps that are needed by the build script to finish
+ESSENTIAL_PKG_TO_KEEP=" $(chroot $BUILD_ROOT rpm --qf '%{NAME}\n' -qf /usr/bin/{date,cat,rm,chown,find,su,gzip,cpio,sh} $(readlink -f /usr/bin/sh)|sort -u|xargs) "
 
 for RPM in `reorder "${RPM_FILE_LIST[@]}"`; do
     PKG=${RPM##*/}
@@ -78,21 +74,26 @@ for RPM in `reorder "${RPM_FILE_LIST[@]}"`; do
 	echo "(keeping $PKG because of $N)"
 	continue
     fi
-    # Do not remove libgcc/libstdc++/libgomp variants or rpm/rpm-build/rpm-ndb
-    case ${PKG} in
-    libgcc*|libgomp*|libstdc++*)
-	;;
-    $coreutils|$utillinux|$shell|$findutils|$gzip|$cpio)
-	;;
-    bash-legacybin*|glibc-usrmerge-bootstrap-helper)
-	;;
-    pam_unix*)
-	;;
-    rpm|rpm-build|rpm-ndb)
-	;;
+
+    # do not remove essential packages
+    case "$ESSENTIAL_PKG_TO_KEEP" in
+    *" $PKG "*)
+        ;;
     *)
-	RPM_ERASE_LIST="$RPM_ERASE_LIST $PKG"
-	;;
+        # Do not remove libgcc/libstdc++/libgomp variants or rpm/rpm-build/rpm-ndb
+        case ${PKG} in
+        libgcc*|libgomp*|libstdc++*)
+            ;;
+        bash-legacybin*|glibc-usrmerge-bootstrap-helper)
+            ;;
+        pam_unix*)
+            ;;
+        rpm|rpm-build|rpm-ndb)
+            ;;
+        *)
+            RPM_ERASE_LIST="$RPM_ERASE_LIST $PKG"
+            ;;
+        esac
     esac
 done
 test -z "$REORDER_MISSED" || echo "    (reorder missed ${REORDER_MISSED% })"


### PR DESCRIPTION
Previously only the bash-sh was preserved, now also the target
of the symlink is marked as to be kept. this allows other dropins
like dash to be providing a /usr/bin/sh symlink.

Also cleanup the code to avoid repeated calls to rpm in the chroot.