### PR TITLE
use predictable C locale for rpm listing

### DIFF
--- a/checks/50-check-invalid-provides
+++ b/checks/50-check-invalid-provides
@@ -4,22 +4,22 @@
 TOPDIR=/usr/src/packages
 test -d $BUILD_ROOT/.build.packages && TOPDIR=/.build.packages
 
-export UNVALID_FILE_FOUND=false
+export INVALID_FILE_FOUND=false
 
-for package in `find $BUILD_ROOT$TOPDIR/RPMS -name "*.rpm"` ; do
-  if rpm -qp --provides --nodigest --nosignature $package \
-     | grep -q -E "^$(rpm -qp --nodigest --nosignature --queryformat='%{NAME}' $package)[[:space:]]*$"; then
+RPM="env LC_ALL=C rpm --macros=/dev/null --nodigest --nosignature"
 
+for package in `find $BUILD_ROOT$TOPDIR/RPMS -type f -name "*.rpm"` ; do
+  if $RPM -qp --provides $package | grep -q -E "^$($RPM -qp --qf='%{NAME}' $package)[[:space:]]*$"; then
     echo ""
     echo "ERROR: ${package##$BUILD_ROOT}"
     echo "       has an unversioned self-provide. "
     echo "       Remove it, self-provides are done automatically."
     echo "       If you don't understand this error message, contact dmueller@suse.de"
     echo ""
-    UNVALID_FILE_FOUND=true
+    INVALID_FILE_FOUND=true
   fi
 done
 
-test $UNVALID_FILE_FOUND = true && exit 1
+test $INVALID_FILE_FOUND = true && exit 1
 
 exit 0

--- a/checks/50-check-permissions
+++ b/checks/50-check-permissions
@@ -12,7 +12,7 @@ grep -q "secure local" $BUILD_ROOT/etc/sysconfig/security || {
     HAD_ERRORS=1
 }
 
-RPM="chroot $BUILD_ROOT rpm --nodigest --nosignature -Vp --nofiledigest --nodeps"
+RPM="chroot $BUILD_ROOT env LC_ALL=C rpm --nodigest --nosignature -Vp --nofiledigest --nodeps"
 
 for i in $(find $BUILD_ROOT$TOPDIR/RPMS -type f -name "*.rpm" | sort) ; do
     case "$pkg" in


### PR DESCRIPTION
this also saves a bit of time on builds with large number of subpackages.