### PR TITLE
Convert egrep/fgrep calls to grep -E/-F, respectively

### DIFF
--- a/checks/50-check-invalid-requires
+++ b/checks/50-check-invalid-requires
@@ -9,7 +9,7 @@ RPM="chroot $BUILD_ROOT rpm --nodigest --nosignature"
 
 FORBIDDEN_REQ=`find $BUILD_ROOT$TOPDIR/RPMS -name "*.rpm" | \
     xargs --no-run-if-empty rpm -qp --requires| \
-    egrep "/usr/local/|/usr/share/bin"`
+    grep -E "/usr/local/|/usr/share/bin"`
 
 for LINE in $FORBIDDEN_REQ; do
         case "$LINE" in

--- a/checks/50-check-libtool-deps
+++ b/checks/50-check-libtool-deps
@@ -3,6 +3,7 @@
 # Check dependencies required by libtool to use .la files.
 #
 # Copyright (C) 2005 Stanislav Brabec <sbrabec@suse.cz>, SuSE CR
+# Copyright (C) 2022 Andreas Stieger <Andreas.Stieger@gmx.de>
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -186,7 +187,7 @@ Please add proper package to neededforbuild to complete this check."
 
 echo "... testing devel dependencies required by libtool .la files"
 
-if fgrep -q skip-check-libtool-deps "$BUILD_ROOT"$TOPDIR/SOURCES/$PNAME.spec ; then
+if grep -F -q skip-check-libtool-deps "$BUILD_ROOT"$TOPDIR/SOURCES/$PNAME.spec ; then
     echo "    skipped by \"skip-check-libtool-deps\""
     exit 0
 fi


### PR DESCRIPTION
grep 3.8 starts throwing warnings, and `egrep`/`fgrep` will be dropped long term
https://bugzilla.opensuse.org/show_bug.cgi?id=1203092