### PR TITLE
Follow symlinks to infer which packages to keep

### DIFF
--- a/checks/99-check-remove-rpms
+++ b/checks/99-check-remove-rpms
@@ -53,7 +53,7 @@ RPM_ERASE_LIST=
 RPM_FILE_LIST=(`find $BUILD_ROOT$TOPDIR/RPMS -type f -name "*.rpm"`)
 
 # essential deps that are needed by the build script to finish
-ESSENTIAL_PKG_TO_KEEP=" $(chroot $BUILD_ROOT rpm --qf '%{NAME}\n' -qf /usr/bin/{date,cat,rm,chown,find,su,gzip,cpio,sh} $(readlink -f /usr/bin/sh)|sort -u|xargs) "
+ESSENTIAL_PKG_TO_KEEP=" $(chroot $BUILD_ROOT rpm --qf '%{NAME}\n' -qf /usr/bin/{date,cat,rm,chown,find,su,gzip,cpio,sh} $(readlink -f /usr/bin/{date,cat,rm,chown,find,su,gzip,cpio,sh})|sort -u|xargs) "
 
 for RPM in `reorder "${RPM_FILE_LIST[@]}"`; do
     PKG=${RPM##*/}


### PR DESCRIPTION
`99-check-remove-rpms` tries to **not** remove packages that provide essential utilities like `cat`, `date`, `rm`, etc. Before this commit, it would only check for the actual file, but tiny coreutils replacements like `toybox` or `busybox` often provide `-symlink` packages, which provide a bunch of symlinks from `/usr/bin/rm -> /bin/{busybox,toybox}`.
`99-check-remove-rpms` would then keep the symlink package, but remove `toybox`/`busybox` effectively breaking the buildroot. By adding a `readlink` check, we will no longer remove `busybox` & `toybox` in such a case.