### PR TITLE
Add mount, umount, swapon and swapoff to ESSENTIAL_PKG_TO_KEEP

### DIFF
--- a/checks/99-check-remove-rpms
+++ b/checks/99-check-remove-rpms
@@ -53,7 +53,7 @@ RPM_ERASE_LIST=
 RPM_FILE_LIST=(`find $BUILD_ROOT$TOPDIR/RPMS -type f -name "*.rpm"`)
 
 # essential deps that are needed by the build script to finish
-ESSENTIAL_PKG_TO_KEEP=" $(chroot $BUILD_ROOT rpm --qf '%{NAME}\n' -qf /usr/bin/{date,cat,rm,chown,find,su,gzip,cpio,sh} $(readlink -f /usr/bin/{date,cat,rm,chown,find,su,gzip,cpio,sh})|sort -u|xargs) "
+ESSENTIAL_PKG_TO_KEEP=" $(chroot $BUILD_ROOT rpm --qf '%{NAME}\n' -qf /usr/bin/{date,cat,rm,chown,find,su,gzip,cpio,sh,mount,umount} /sbin/{swapon,swapoff} $(readlink -f /usr/bin/{date,cat,rm,chown,find,su,gzip,cpio,sh})|sort -u|xargs) "
 
 for RPM in `reorder "${RPM_FILE_LIST[@]}"`; do
     PKG=${RPM##*/}


### PR DESCRIPTION
Some util-linux binaries are needed to run and shutdown the VM.

This change is needed to build util-linux-mini conflicting with util-linux. Otherwise the build uninstalls umount and swapoff and the VM will fail to land.