### PR TITLE
Add abuild to trusted group without using usermod

### DIFF
--- a/finalize-system/01-add_abuild_user_to_trusted_group
+++ b/finalize-system/01-add_abuild_user_to_trusted_group
@@ -15,4 +15,9 @@ grep -q "^abuild:" /etc/passwd || {
 
 }
 
-id abuild >/dev/null 2>/dev/null && usermod -G trusted -a abuild || true
+if id abuild >/dev/null 2>/dev/null; then
+    # add abuild to trusted auxiliary group
+    if ! id -nG abuild 2> /dev/null | grep -q trusted; then
+        sed -i -E -e 's|trusted:([^:]+):([^:]+):(.*)|trusted:\1:\2:abuild,\3|' /etc/group
+    fi
+fi


### PR DESCRIPTION
That is no longer installed in Tumbleweed buildenvs, we can do without