### PR TITLE
Guard against "integer expression expected" error

### DIFF
--- a/suse-buildsystem.sh
+++ b/suse-buildsystem.sh
@@ -50,7 +50,8 @@ if test ! -v SOURCE_DATE_EPOCH && test -f /.buildenv && test "Y" != "$(rpm --eva
         export SOURCE_DATE_EPOCH_MTIME
         export SOURCE_DATE_EPOCH
     fi
-    if test "$SOURCE_DATE_EPOCH_MTIME" -ge "$(date '+%s')" ; then
+    if [ -n "$SOURCE_DATE_EPOCH_MTIME" ] &&
+       [ "$SOURCE_DATE_EPOCH_MTIME" -ge "$(date '+%s')" ]; then
         echo "WARNING SOURCE_DATE_EPOCH_MTIME is in the future, we assume you do not use clamping of mtime, it would fail in hard to notice ways, continuing" >&2
     fi
 fi


### PR DESCRIPTION
```
[    2s] WARNING could not set SOURCE_DATE_EPOCH, ensure BUILD_RELEASE is set in /.buildenv
[    2s] /etc/profile.d/suse-buildsystem.sh: line 53: test: : integer expression expected
```

There are `unset` statements right above the `-ge` test, but `-ge` must only ever be called with number input (which an unset variable is not).