### PR TITLE
Add codegen-units=1 for deterministic rust builds

### DIFF
--- a/suse-buildsystem.sh
+++ b/suse-buildsystem.sh
@@ -7,6 +7,7 @@ export QT_HASH_SEED=0
 export PERL_HASH_SEED=42
 export PYTHONHASHSEED=0
 export FORCE_SOURCE_DATE=1 # for texlive to use SOURCE_DATE_EPOCH
+export RUSTFLAGS="-C codegen-units=1"
 
 if test ! -v SOURCE_DATE_EPOCH && test -f /.buildenv && test "Y" != "$(rpm --eval '%disable_obs_set_source_date_epoch')"; then
     SOURCE_DATE_EPOCH="$(


### PR DESCRIPTION
The default is 16 and causes rust build results to vary (e.g. in pop-launcher and python-libcst). See https://reproducible-builds.org/ for why this matters.

https://doc.rust-lang.org/nightly/rustc/codegen-options/index.html#codegen-units and https://nnethercote.github.io/perf-book/build-configuration.html#codegen-units has some background info on this option.

This makes 4-core builds slightly slower and 1-core builds slightly faster. It can also produce better optimizations for the resulting binary.

This patch was done while working on reproducible builds for openSUSE, sponsored by the NLnet NGI0 fund.