### PR TITLE
50-check-permissions: Fix permctl level changes

### DIFF
--- a/checks/50-check-permissions
+++ b/checks/50-check-permissions
@@ -31,7 +31,7 @@ for i in $(find $BUILD_ROOT$TOPDIR/RPMS -type f -name "*.rpm" | LC_ALL=C sort) ;
     chroot $BUILD_ROOT /usr/bin/chkstat --set --system >/dev/null 2>&1
     if ! cmp -s $BUILD_ROOT/.build_rpmVp_orig $BUILD_ROOT/.build_rpmVp_easy; then
 	echo "--------------------------------------------------------------------"
-	echo "ERROR: chkstat --level secure modified package $(rpm --nodigest --nosignature -qp --qf '%{NAME}' \"$i\")"
+	echo "ERROR: chkstat --level secure modified package $(rpm --nodigest --nosignature -qp --qf '%{NAME}' "$i")"
 	echo "Please add '%verify(not mode,...) for those to avoid listings in rpm -V."
 	echo "diff for both runs of rpm -V:"
 	diff -u0 "$BUILD_ROOT/.build_rpmVp_orig" "$BUILD_ROOT/.build_rpmVp_easy"
@@ -40,8 +40,8 @@ for i in $(find $BUILD_ROOT$TOPDIR/RPMS -type f -name "*.rpm" | LC_ALL=C sort) ;
     fi
     if ! cmp -s $BUILD_ROOT/.build_rpmVp_orig $BUILD_ROOT/.build_rpmVp_paranoid; then
 	echo "--------------------------------------------------------------------"
-        echo "ERROR: chkstat --level paranoid modified package $(rpm --nodigest --nosignature -qp --qf '%{NAME}' \"$i\")"
-        echo "Please add '%verify(not mode,...) for those to avoid listings in rpm -V."
+	echo "ERROR: chkstat --level paranoid modified package $(rpm --nodigest --nosignature -qp --qf '%{NAME}' "$i")"
+	echo "Please add '%verify(not mode,...) for those to avoid listings in rpm -V."
 	echo "diff for both runs of rpm -V:"
 	diff -u0 "$BUILD_ROOT/.build_rpmVp_orig" "$BUILD_ROOT/.build_rpmVp_paranoid"
 	echo "--------------------------------------------------------------------"

--- a/checks/50-check-permissions
+++ b/checks/50-check-permissions
@@ -19,11 +19,11 @@ for i in $(find $BUILD_ROOT$TOPDIR/RPMS -type f -name "*.rpm" | LC_ALL=C sort) ;
         *-debuginfo-*|*-debugsource-*) continue ;;
     esac
     $RPM ${i#$BUILD_ROOT} > $BUILD_ROOT/.build_rpmVp_orig
-    sed -i.bak -e "s@^PERMISSION_SECURITY\(.*\)@PERMISSION_SECURITY = \"easy local\"@" \
+    sed -i.bak -e "s@^PERMISSION_SECURITY\(.*\)@PERMISSION_SECURITY=\"easy local\"@" \
            $BUILD_ROOT/etc/sysconfig/security
     chroot $BUILD_ROOT /usr/bin/chkstat --set --system >/dev/null 2>&1
     $RPM ${i#$BUILD_ROOT} > $BUILD_ROOT/.build_rpmVp_easy
-    sed -i -e "s@^PERMISSION_SECURITY\(.*\)@PERMISSION_SECURITY = \"paranoid local\"@" \
+    sed -i -e "s@^PERMISSION_SECURITY\(.*\)@PERMISSION_SECURITY=\"paranoid local\"@" \
            $BUILD_ROOT/etc/sysconfig/security
     chroot $BUILD_ROOT /usr/bin/chkstat --set --system >/dev/null 2>&1
     $RPM ${i#$BUILD_ROOT} > $BUILD_ROOT/.build_rpmVp_paranoid


### PR DESCRIPTION
Spaces around = are invalid and made it fall back to "secure" in both cases.