### PR TITLE
99-check-remove-rpms: don't remove libsframe*

### DIFF
--- a/checks/99-check-remove-rpms
+++ b/checks/99-check-remove-rpms
@@ -90,6 +90,8 @@ for RPM in `reorder "${RPM_FILE_LIST[@]}"`; do
             ;;
         rpm|rpm-build|rpm-ndb)
             ;;
+        libsframe*)
+            ;;
         *)
             RPM_ERASE_LIST="$RPM_ERASE_LIST $PKG"
             ;;


### PR DESCRIPTION
binutils will soon require libsframe2.  When that's the case post-build-checks removing libsframe2 will break the binutils that were just installed by the rpm install post-build-check, thereby ultimately breaking rpmlint which internally uses readelf and ar.

This will happen only during the transition from non-existent libsframe2 to ones requiring it, as afterwards libsframe2 won't be removed due to it being already installed from the very beginning.

For now I have some work-around in the binutils package that uses static linking during this transition period.  But even nicer would be post-build-checks not removing libsframe from under my seat :-)