### PR TITLE
Set TOPDIR in shell profile

### DIFF
--- a/suse-buildsystem.sh
+++ b/suse-buildsystem.sh
@@ -7,6 +7,7 @@ export QT_HASH_SEED=0
 export PERL_HASH_SEED=42
 export PYTHONHASHSEED=0
 export FORCE_SOURCE_DATE=1 # for texlive to use SOURCE_DATE_EPOCH
+export TOPDIR=`rpm --eval '%_topdir'`
 
 if test ! -v SOURCE_DATE_EPOCH && test -f /.buildenv && test "Y" != "$(rpm --eval '%disable_obs_set_source_date_epoch')"; then
     SOURCE_DATE_EPOCH="$(


### PR DESCRIPTION
Ever since
commit d664cd85c8c9fe9f17895e137e2ecb54b43e150c
Author: Jan Zerebecki <jan.suse@zerebecki.de>
Date:   Mon Oct 2 19:07:53 2023 +0200

    Set SOURCE_DATE_EPOCH (2nd try)

the script makes use of the variable TOPDIR, but this isn't set anywhere. (The caller `build` has it set, but this doesn't survive `su`).
The easiest way to obtain it is to call `rpm` - since this is for a SUSE build it should be available.